### PR TITLE
Fix apt package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ output/               # Dados gerados
 Para sistemas Linux, instale as dependências do sistema:
 ```bash
 apt-get update && apt-get install -y \
-    libpango1.0-0 \
+    libpango-1.0-0 \
     libharfbuzz0b \
     libpangoft2-1.0-0 \
-    libffi7 \
+    libffi8 \
     libjpeg-dev \
     libopenjp2-7-dev \
     libcairo2

--- a/packages.txt
+++ b/packages.txt
@@ -1,7 +1,7 @@
-libpango1.0-0
+libpango-1.0-0
 libharfbuzz0b
 libpangoft2-1.0-0
-libffi7
+libffi8
 libjpeg-dev
 libopenjp2-7-dev
 libcairo2


### PR DESCRIPTION
## Summary
- fix package names in packages.txt
- update README with correct package names

## Testing
- `python -m py_compile streamlit_app.py src/*/*.py main.py`
- `sudo xargs apt-get install -y < packages.txt`

------
https://chatgpt.com/codex/tasks/task_e_684098a5c7e48332b1f6723471c56002